### PR TITLE
Output logs to S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN ~/.rbenv/bin/rbenv exec gem install bundler -v 2.1.4
 
 WORKDIR /src/digdag
 EXPOSE 65432
-CMD ["java", "-jar", "/root/bin/digdag", "scheduler", "-m"]
+CMD ["java", "-jar", "/root/bin/digdag", "scheduler", "-m", "-c", "config.properties"]

--- a/src/digdag/config.properties
+++ b/src/digdag/config.properties
@@ -1,0 +1,3 @@
+log-server.type = s3
+log-server.s3.bucket = digdag-logs
+log-server.s3.path = /logs


### PR DESCRIPTION
## Why

Output logs to S3

## What

Setting up properties. refs: https://docs.digdag.io/command_reference.html#id7